### PR TITLE
Adding class to an element that already had a class would fail

### DIFF
--- a/domtemplate.php
+++ b/domtemplate.php
@@ -334,7 +334,7 @@ abstract class DOMTemplateNode {
 	private function setClassNode ($DOMNode, $class) {
 		//check if the class node already has the className (don't add twice)
 		if (!in_array ($class, explode (' ', $DOMNode->nodeValue)))
-			@$node->nodeValue = $DOMNode->nodeValue." $class"
+			@$DOMNode->nodeValue = $DOMNode->nodeValue." $class"
 		;
 	}
 	


### PR DESCRIPTION
If an element have a class attribute and we try to use the addClass function, the new class would not be appended.

The $node variable does not exists in setClassNode, it should be $DOMNode.
