### PR TITLE
Fix void HTML tags handling

### DIFF
--- a/domtemplate.php
+++ b/domtemplate.php
@@ -146,7 +146,7 @@ abstract class DOMTemplateNode {
 		// [2] properly self-close some elments
 		$text = preg_replace (
 			'/<(area|base|basefont|br|col|embed|hr|img|input|keygen|link|'.
-			'menuitem|meta|param|source|track|wbr)\b([^>]*)(?<!\/)>(?!<\/$1>)/is',
+			'menuitem|meta|param|source|track|wbr)\b([^>]*)(?<!\/)>(?!<\/\1>)/is',
 			'<$1$2 />', $text
 		);
 		// [3] convert HTML-style attributes (`<a attr>`)

--- a/domtemplate.php
+++ b/domtemplate.php
@@ -146,8 +146,8 @@ abstract class DOMTemplateNode {
 		// [2] properly self-close some elments
 		$text = preg_replace (
 			'/<(area|base|basefont|br|col|embed|hr|img|input|keygen|link|'.
-			'menuitem|meta|param|source|track|wbr)\b([^>]*)(?<!\/)>(?!<\/\1>)/is',
-			'<$1$2 />', $text
+			'menuitem|meta|param|source|track|wbr)\b([^>]*)(?<!\/)>(?!<\/\1>)'.
+			'/is', '<$1$2 />', $text
 		);
 		// [3] convert HTML-style attributes (`<a attr>`)
 		// to XML style attributes (`<a attr="attr">`)

--- a/domtemplate.php
+++ b/domtemplate.php
@@ -38,7 +38,7 @@ class DOMTemplate extends DOMTemplateNode {
 	const HTML = 0;
 	const XML  = 1;
 
-	// a table of HTML entites to reverse:
+	// a table of HTML entities to reverse:
 	// '&', '<', '>' are removed so we don’t turn user text into working HTML!
 	//
 	// TODO: moving DOMTemplate to a namespace will allow us to use
@@ -133,7 +133,7 @@ abstract class DOMTemplateNode {
 		);
 	}
 
-	// toXML : convert string input to safe XML for inporting into DOM
+	// toXML : convert string input to safe XML for importing into DOM
 	//--------------------------------------------------------------------------
 	// TODO: even though this isn't static, we seem to be able to call it
 	//		 statically!?
@@ -143,7 +143,7 @@ abstract class DOMTemplateNode {
 		// back to real UTF-8 characters (which XML doesn’t mind)
 		$text = $this->html_entity_decode ($text);
 
-		// [2] properly self-close some elments
+		// [2] properly self-close some elements
 		$text = preg_replace (
 			'/<(area|base|basefont|br|col|embed|hr|img|input|keygen|link|'.
 			'menuitem|meta|param|source|track|wbr)\b([^>]*)(?<!\/)>(?!<\/\1>)'.
@@ -316,7 +316,7 @@ abstract class DOMTemplateNode {
 			// if the text is to be inserted as HTML
 			// that will be included into the output
 			case $asHTML:
-				// remove exisiting element's content
+				// remove existing element's content
 				$node->nodeValue = '';
 				// if supplied text is blank end here;
 				// you can't append a blank!
@@ -476,7 +476,7 @@ abstract class DOMTemplateNode {
 	public function repeat ($query) {
 		// NOTE: the provided XPath query could return more than one element!
 		// `DOMTemplateRepeaterArray` therefore acts as a simple wrapper to
-		// propogate changes to all the matched nodes (`DOMTemplateRepeater`)
+		// propagate changes to all the matched nodes (`DOMTemplateRepeater`)
 		return new DOMTemplateRepeaterArray (
 			$this->query ($query), $this->namespaces
 		);

--- a/domtemplate.php
+++ b/domtemplate.php
@@ -426,16 +426,19 @@ abstract class DOMTemplateNode {
 		// differently depending on desired output format
 		$source = $this->DOMNode->ownerDocument->saveXML (
 			// if you’re calling this function from the template-root
-			// we don’t specify a node, otherwise the DOCTYPE / XML prolog
-			// won’t be included
+			// we don’t specify a node, otherwise the DOCTYPE / XML
+			// prolog won’t be included
 			get_class ($this) == 'DOMTemplate' ? NULL : $this->DOMNode,
 			// expand all self-closed tags if for HTML
 			$this->type == 0 ? LIBXML_NOEMPTYTAG : 0
 		);
 
-		// XML is already used for the internal representation; if outputting
-		// XML no filtering is needed (`$this->XML` and `$this::XML` don't
-		// work consistently between PHP versions, so I'm cheeping out)
+		// XML is already used for the internal representation;
+		// if outputting XML no filtering is needed
+		//
+		// note that `$this->XML` and `$this::XML` don't work consistently
+		// between PHP versions and `self::XML` isn't working either,
+		// possibly due to this being either an abstract class definition)
 		if ($this->type == 1) return $source;
 
 		// fix and clean DOM's XML into HTML:

--- a/domtemplate.php
+++ b/domtemplate.php
@@ -444,7 +444,7 @@ abstract class DOMTemplateNode {
 		// <https://html.spec.whatwg.org/#void-elements>
 		$source = preg_replace (
 			'/<(area|base|basefont|br|col|embed|hr|img|input|keygen|link|'.
-			'menuitem|meta|param|source|track|wbr)\b([^>]*)(?<!\/)>(<\/\1>)/is',
+			'menuitem|meta|param|source|track|wbr)\b([^>]*)(?<!\/)><\/\1>/is',
 			'<$1$2 />', $source
 		);
 		// convert XML-style attributes (`<a attr="attr">`) to HTML-style


### PR DESCRIPTION
Hi Kroc!

I’m submitting two fixes. The first one resolves tag name collisions. The second one resolves issue of HTML tags being wrongly self-closed.

The method `toXML` converts void HTML tags to valid XML before passing the string to DOMDocument. Due to regex quirk it is greedy sometimes. Take an example from [MDN article about `colgroup` tag][colgroup].

[colgroup]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup

    <table>
        <caption>Superheros and sidekicks</caption>
        <colgroup>
            <col>
            <col span="2" class="batman">
            <col span="2" class="flash">
        </colgroup>
        <tr>
            <td> </td>
            <th scope="col">Batman</th>
            <th scope="col">Robin</th>
            <th scope="col">The Flash</th>
            <th scope="col">Kid Flash</th>
        </tr>
        <tr>
            <th scope="row">Skill</th>
            <td>Smarts</td>
            <td>Dex, acrobat</td>
            <td>Super speed</td>
            <td>Super speed</td>
        </tr>
    </table>

DOMTemplate will throw an exception even though it was given a valid HTML string. The reason for that is the regex that supposed to properly self-close elements catches `colgroup` element and closes it, leaving its closing tag hanging. Looking at the first portion of the regex—simplified—it is `<col[^>]*`. It will match `<colgroup` and self-close it, resulting in invalid XML.

    <table>
        <caption>Superheros and sidekicks</caption>
        <colgroup /> <!-- WRONGLY SELF-CLOSED -->
            <col />
            <col span="2" class="batman" />
            <col span="2" class="flash" />
        </colgroup> <!-- LEFT HANGING -->
        <tr>
            <td> </td>
            <th scope="col">Batman</th>
            <th scope="col">Robin</th>
            <th scope="col">The Flash</th>
            <th scope="col">Kid Flash</th>
        </tr>
        <tr>
            <th scope="row">Skill</th>
            <td>Smarts</td>
            <td>Dex, acrobat</td>
            <td>Super speed</td>
            <td>Super speed</td>
        </tr>
    </table>

To prevent that from happening I added a word boundry assertion. Now the same regex looks like this  `<col\b[^>]*`, which means the `[^>]*` kicks in when the symbol after `col` isn’t a part of a word. That elliminates an exception in `toXML` method.

When DOMTemplate converts its DOMNode into a string it tries to fix empty elements that were self-closed by DOMDocument. To do this it has to maintain a list of all HTML elements except for void ones and expand them to produce valid HTML.

What I propose is to make DOMDocument expand all the tags on string conversion using `LIBXML_NOEMPTYTAG` option. Then using a list of [HTML void elements][], which is short and less likely to change, self-close the tags that should be.

[HTML void elements]: https://html.spec.whatwg.org/#void-elements