### PR TITLE
Fix DOMTemplateRepeater regression

### DIFF
--- a/domtemplate.php
+++ b/domtemplate.php
@@ -117,7 +117,6 @@ abstract class DOMTemplateNode {
 		// <https://html.spec.whatwg.org/multipage/named-characters.html>
 		//
 		if (is_null($htmlentities)) {
-			error_log('hi');
 			$htmlentities = array_flip (array_diff (
 				get_html_translation_table(
 					HTML_ENTITIES, ENT_NOQUOTES | ENT_HTML401, 'UTF-8'

--- a/domtemplate.php
+++ b/domtemplate.php
@@ -146,7 +146,7 @@ abstract class DOMTemplateNode {
 		// [2] properly self-close some elments
 		$text = preg_replace (
 			'/<(area|base|basefont|br|col|embed|hr|img|input|keygen|link|'.
-			'menuitem|meta|param|source|track|wbr)\b([^>]*)(?<!\/)>(?!<\/$1>)/is',
+			'menuitem|meta|param|source|track|wbr)\b([^>]*)(?<!\/)>(?!<\/\1>)/is',
 			'<$1$2 />', $text
 		);
 		// [3] convert HTML-style attributes (`<a attr>`)

--- a/domtemplate.php
+++ b/domtemplate.php
@@ -146,8 +146,8 @@ abstract class DOMTemplateNode {
 		// [2] properly self-close some elments
 		$text = preg_replace (
 			'/<(area|base|basefont|br|col|embed|hr|img|input|keygen|link|'.
-			'menuitem|meta|param|source|track|wbr)\b([^>]*)(?<!\/)>(?!<\/\1>)/is',
-			'<$1$2 />', $text
+			'menuitem|meta|param|source|track|wbr)\b([^>]*)(?<!\/)>(?!<\/\1>)'.
+			'/is', '<$1$2 />', $text
 		);
 		// [3] convert HTML-style attributes (`<a attr>`)
 		// to XML style attributes (`<a attr="attr">`)

--- a/domtemplate.php
+++ b/domtemplate.php
@@ -38,7 +38,7 @@ class DOMTemplate extends DOMTemplateNode {
 	const HTML = 0;
 	const XML  = 1;
 
-	// a table of HTML entites to reverse:
+	// a table of HTML entities to reverse:
 	// '&', '<', '>' are removed so we don’t turn user text into working HTML!
 	//
 	// TODO: moving DOMTemplate to a namespace will allow us to use
@@ -133,7 +133,7 @@ abstract class DOMTemplateNode {
 		);
 	}
 
-	// toXML : convert string input to safe XML for inporting into DOM
+	// toXML : convert string input to safe XML for importing into DOM
 	//--------------------------------------------------------------------------
 	// TODO: even though this isn't static, we seem to be able to call it
 	//		 statically!?
@@ -143,7 +143,7 @@ abstract class DOMTemplateNode {
 		// back to real UTF-8 characters (which XML doesn’t mind)
 		$text = $this->html_entity_decode ($text);
 
-		// [2] properly self-close some elments
+		// [2] properly self-close some elements
 		$text = preg_replace (
 			'/<(area|base|basefont|br|col|embed|hr|img|input|keygen|link|'.
 			'menuitem|meta|param|source|track|wbr)\b([^>]*)(?<!\/)>(?!<\/\1>)'.
@@ -316,7 +316,7 @@ abstract class DOMTemplateNode {
 			// if the text is to be inserted as HTML
 			// that will be included into the output
 			case $asHTML:
-				// remove exisiting element's content
+				// remove existing element's content
 				$node->nodeValue = '';
 				// if supplied text is blank end here;
 				// you can't append a blank!
@@ -476,7 +476,7 @@ abstract class DOMTemplateNode {
 	public function repeat ($query) {
 		// NOTE: the provided XPath query could return more than one element!
 		// `DOMTemplateRepeaterArray` therefore acts as a simple wrapper to
-		// propogate changes to all the matched nodes (`DOMTemplateRepeater`)
+		// propagate changes to all the matched nodes (`DOMTemplateRepeater`)
 		return new DOMTemplateRepeaterArray (
 			$this->query ($query), $this->namespaces
 		);

--- a/domtemplate.php
+++ b/domtemplate.php
@@ -426,16 +426,19 @@ abstract class DOMTemplateNode {
 		// differently depending on desired output format
 		$source = $this->DOMNode->ownerDocument->saveXML (
 			// if you’re calling this function from the template-root
-			// we don’t specify a node, otherwise the DOCTYPE / XML prolog
-			// won’t be included
+			// we don’t specify a node, otherwise the DOCTYPE / XML
+			// prolog won’t be included
 			get_class ($this) == 'DOMTemplate' ? NULL : $this->DOMNode,
 			// expand all self-closed tags if for HTML
 			$this->type == 0 ? LIBXML_NOEMPTYTAG : 0
 		);
 
-		// XML is already used for the internal representation; if outputting
-		// XML no filtering is needed (`$this->XML` and `$this::XML` don't
-		// work consistently between PHP versions, so I'm cheeping out)
+		// XML is already used for the internal representation;
+		// if outputting XML no filtering is needed
+		//
+		// note that `$this->XML` and `$this::XML` don't work consistently
+		// between PHP versions and `self::XML` isn't working either,
+		// possibly due to this being either an abstract class definition)
 		if ($this->type == 1) return $source;
 
 		// fix and clean DOM's XML into HTML:

--- a/domtemplate.php
+++ b/domtemplate.php
@@ -444,7 +444,7 @@ abstract class DOMTemplateNode {
 		// <https://html.spec.whatwg.org/#void-elements>
 		$source = preg_replace (
 			'/<(area|base|basefont|br|col|embed|hr|img|input|keygen|link|'.
-			'menuitem|meta|param|source|track|wbr)\b([^>]*)(?<!\/)>(<\/\1>)/is',
+			'menuitem|meta|param|source|track|wbr)\b([^>]*)(?<!\/)><\/\1>/is',
 			'<$1$2 />', $source
 		);
 		// convert XML-style attributes (`<a attr="attr">`) to HTML-style


### PR DESCRIPTION
Move HTML entities array inside html_entity_decode method as a static
variable.

Fixes #25.