### PR TITLE
Define abstract class first

### DIFF
--- a/domtemplate.php
+++ b/domtemplate.php
@@ -27,64 +27,6 @@
 			append the sub-template to the list and reset its content
 */
 
-// class DOMTemplate : the overall template controller
-//==============================================================================
-class DOMTemplate extends DOMTemplateNode {
-	// internal reference to the PHP `DOMDocument` for the template's XML
-	private $DOMDocument;
-
-	// what type of data are we processing?
-	protected $type = self::HTML;
-	const HTML = 0;
-	const XML  = 1;
-
-	// new DOMTemplate : instantiation
-	//--------------------------------------------------------------------------
-	public function __construct (
-		$source,		//a string of the HTML or XML to form the template
-		$namespaces=[]	//an array of XML namespaces if your document uses them,
-						//in the format of `'namespace' => 'namespace URI'`
-	) {
-		// detect the content type; HTML or XML,
-		// HTML will need filtering during input and output
-		// -- does this source have an XML prolog?
-		$this->type = substr_compare ($source, '<?xml', 0, 4, true) === 0
-					? self::XML : self::HTML
-		;
-		// load the template file to work with,
-		// it _must_ have only one root (wrapping) element; e.g. `<html>`
-		$this->DOMDocument = new DOMDocument ();
-		if (!$this->DOMDocument->loadXML (
-			// if the source is HTML add an XML prolog
-			// to avoid mangling unicode characters, see
-			// <php.net/manual/en/domdocument.loadxml.php#94291>,
-			// also convert it to XML for PHP DOM use
-			$this->type == self::HTML
-			? "<?xml version=\"1.0\" encoding=\"utf-8\"?>".self::toXML ($source)
-			: $source,
-			// <https://www.php.net/manual/en/libxml.constants.php>
-			@LIBXML_COMPACT ||	// libxml >= 2.6.21
-			@LIBXML_NONET		// do not connect to external resources
-		)) trigger_error (
-			"Source is invalid XML", E_USER_ERROR
-		);
-		// set the root node for all XPath searching
-		// (handled all internally by `DOMTemplateNode`)
-		parent::__construct ($this->DOMDocument->documentElement, $namespaces);
-	}
-
-	// output the document (cast the object to a string, i.e. `echo $template;`)
-	//--------------------------------------------------------------------------
-	public function __toString () {
-		// if the input was HTML, remove the XML prolog on output
-		return $this->type == self::HTML
-		?	// we defer to DOMTemplateNode which returns the HTML for any node,
-			// the top-level template only needs to consider the prolog
-			preg_replace ('/^<\?xml[^<]*>\n/', '', parent::__toString ())
-		:	parent::__toString ();
-	}
-}
-
 // class DOMTemplateNode
 //==============================================================================
 // these methods are shared between the base `DOMTemplate` and the repeater
@@ -484,6 +426,64 @@ abstract class DOMTemplateNode {
 		return new DOMTemplateRepeaterArray (
 			$this->query ($query), $this->namespaces
 		);
+	}
+}
+
+// class DOMTemplate : the overall template controller
+//==============================================================================
+class DOMTemplate extends DOMTemplateNode {
+	// internal reference to the PHP `DOMDocument` for the template's XML
+	private $DOMDocument;
+
+	// what type of data are we processing?
+	protected $type = self::HTML;
+	const HTML = 0;
+	const XML  = 1;
+
+	// new DOMTemplate : instantiation
+	//--------------------------------------------------------------------------
+	public function __construct (
+		$source,		//a string of the HTML or XML to form the template
+		$namespaces=[]	//an array of XML namespaces if your document uses them,
+						//in the format of `'namespace' => 'namespace URI'`
+	) {
+		// detect the content type; HTML or XML,
+		// HTML will need filtering during input and output
+		// -- does this source have an XML prolog?
+		$this->type = substr_compare ($source, '<?xml', 0, 4, true) === 0
+					? self::XML : self::HTML
+		;
+		// load the template file to work with,
+		// it _must_ have only one root (wrapping) element; e.g. `<html>`
+		$this->DOMDocument = new DOMDocument ();
+		if (!$this->DOMDocument->loadXML (
+			// if the source is HTML add an XML prolog
+			// to avoid mangling unicode characters, see
+			// <php.net/manual/en/domdocument.loadxml.php#94291>,
+			// also convert it to XML for PHP DOM use
+			$this->type == self::HTML
+			? "<?xml version=\"1.0\" encoding=\"utf-8\"?>".self::toXML ($source)
+			: $source,
+			// <https://www.php.net/manual/en/libxml.constants.php>
+			@LIBXML_COMPACT ||	// libxml >= 2.6.21
+			@LIBXML_NONET		// do not connect to external resources
+		)) trigger_error (
+			"Source is invalid XML", E_USER_ERROR
+		);
+		// set the root node for all XPath searching
+		// (handled all internally by `DOMTemplateNode`)
+		parent::__construct ($this->DOMDocument->documentElement, $namespaces);
+	}
+
+	// output the document (cast the object to a string, i.e. `echo $template;`)
+	//--------------------------------------------------------------------------
+	public function __toString () {
+		// if the input was HTML, remove the XML prolog on output
+		return $this->type == self::HTML
+		?	// we defer to DOMTemplateNode which returns the HTML for any node,
+			// the top-level template only needs to consider the prolog
+			preg_replace ('/^<\?xml[^<]*>\n/', '', parent::__toString ())
+		:	parent::__toString ();
 	}
 }
 


### PR DESCRIPTION
PHP8 requires abstract classes to be defined before the ones that extend it.

Fixes #29.